### PR TITLE
Limit number of files open simultaneously.

### DIFF
--- a/hash-files/index.js
+++ b/hash-files/index.js
@@ -1,10 +1,11 @@
 const { createHash } = require('crypto')
 const envPaths = require('env-paths')
 const makeDir = require('make-dir')
-const { join, normalize } = require('path')
+const { join } = require('path')
 const fs = require('fs')
 const events = require('events')
 const throttleAsyncFn = require('throttle-async-function')
+const normalize = require('./normalize')
 
 const paths = envPaths('hash-files')
 const cachePath = paths.cache
@@ -63,6 +64,9 @@ const getHash = throttleAsyncFn(async path => {
   // TODO: No need to read again from file if we just wrote to it
   // Read the hash file
   return await fs.promises.readFile(hashFilePath)
+}, {
+  // Only check hash once after process is started
+  cacheRefreshPeriod: Infinity
 })
 
 // TODO: Also make a function that copies the hash of a file to another file

--- a/hash-files/normalize.js
+++ b/hash-files/normalize.js
@@ -1,0 +1,16 @@
+const { normalize: nodeNormalize } = require('path')
+
+/**
+ * This is more than just `path.normalize()`. 
+ * This function simplifies any path so that it's equal to similar path.
+ * 
+ * For example: `c://A//b.txt\` is the same as `C:\\\\a\\\\B.TXT`.
+ * In the example, both simplify to `c:\a\b.txt` (using forward / backwards slashes according to system).
+ * 
+ * @param path {string}
+ */
+const normalize = path => nodeNormalize(path)
+    .replace(/[\/\\]$/, '')
+    .toLowerCase()
+
+module.exports = normalize

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "async": "^3.2.0",
         "fs-extra": "^9.0.1",
         "hash-files": "file:hash-files",
         "recursive-readdir-async": "^1.1.8"
@@ -218,8 +219,7 @@
     "node_modules/async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2414,8 +2414,7 @@
     "async": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-      "dev": true
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "at-least-node": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "electron-packager": "^15.1.0"
   },
   "dependencies": {
+    "async": "^3.2.0",
     "fs-extra": "^9.0.1",
     "hash-files": "file:hash-files",
     "recursive-readdir-async": "^1.1.8"

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ const fsExtra = require('fs-extra')
 const fs = require('fs')
 const { join, basename, dirname, extname, relative } = require('path')
 const getHash = require('hash-files')
+const forEachLimit = require('async/forEachLimit')
+
+const parallelCopyLimit = 100
 
 const form = document.getElementById('form')
 const existSpan = document.getElementById('form__exist-span')
@@ -160,7 +163,7 @@ form.copy.addEventListener('click', async () => {
         createDirs.set(path, promise)
         return promise
     }
-    await Promise.all(readSrc.map(async ({ fullname: srcFilePath }) => {
+    await forEachLimit(readSrc, parallelCopyLimit, async ({ fullname: srcFilePath }) => {
         const relativePath = relative(form.src.value, srcFilePath)
         const srcFileHash = await getHash(srcFilePath)
         const duplicateOf = (await Promise.all(readExist.map(async ({ fullname: existFilePath }) => (
@@ -191,7 +194,7 @@ form.copy.addEventListener('click', async () => {
         )
         filesCopied.add(copiedFileShown)
         updateProgress()
-    }))
+    })
     currentStep++
     updateProgress()
     disable(false)


### PR DESCRIPTION
This let's the program not crash when handling 1k+ files. Also fixed some critical issues about `hash-files`.